### PR TITLE
Update demo link from ngrok.io to ngrok.app

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
                   </a>
                 </span>
                 <span class="link-block">
-                  <a href="https://llavainteractive.ngrok.io/" target="_blank"
+                  <a href="https://llavainteractive.ngrok.app/" target="_blank"
                     class="external-link button is-normal is-rounded is-dark">
                     <span class="icon">
                       <i class="far fa-images"></i>
@@ -214,7 +214,7 @@
                  
       <span class="link-block">
            
-        <a href="https://llavainteractive.ngrok.io/" target="_blank"
+        <a href="https://llavainteractive.ngrok.app/" target="_blank"
           class="external-link button is-normal is-rounded is-dark">
           <span class="icon">
             <i class="far fa-images"></i>
@@ -223,7 +223,7 @@
         </a>
       </span>
 
-      <gradio-app src="https://llavainteractive.ngrok.io/"></gradio-app>
+      <gradio-app src="https://llavainteractive.ngrok.app/"></gradio-app>
     </div>
   </section>
 


### PR DESCRIPTION
## Issue

The demo was using personal account from Chunyuan which we didn't control.
We wanted to switch to Microsoft / MSR owned account so we can control billing and domain.

## Solution

Create new Ngrok account
switched the demo from https://llavainteractive.ngrok.io to https://llavainteractive.ngrok.app/